### PR TITLE
Add other Python backends as dependencies for pipx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+colorthief
+haishoku
+colorz

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
     packages=["pywal_16"],
     entry_points={"console_scripts": ["wal=pywal_16.__main__:main"]},
     python_requires=">=3.5",
+    install_requires=list(open("requirements.txt")),
     test_suite="tests",
     include_package_data=True,
     zip_safe=False)


### PR DESCRIPTION
For tools like pipx which create a virtual env for each Python executable, installing the backends after installing pywal doesn't work without going into the created virtual env by hand and making sure they are installed.

This fixes this and makes sure the backends that are available as Python packages (so not schemer2) are installed in the virtual env by pipx and everything works out of the box.